### PR TITLE
Merge World observation params changes fromSineworld dev

### DIFF
--- a/json_factory.py
+++ b/json_factory.py
@@ -8,7 +8,7 @@ from icecream import ic
 from string import ascii_lowercase
 from math import log, ceil
 import os
-# ic.disable()
+# ic.disable() # --
 
 class IDCoder:
     def __init__(self, n_chars: int, chars=ascii_lowercase):

--- a/json_factory.py
+++ b/json_factory.py
@@ -11,10 +11,10 @@ import os
 # ic.disable() # --
 
 class IDCoder:
-    def __init__(self, n_chars: int, chars=ascii_lowercase):
+    def __init__(self, n_chars: int, chars=ascii_lowercase, i=0):
         self.n = n_chars
         self.chars = chars
-        self.i = 0
+        self.i = i
 
     def __iter__ (self):
         return self

--- a/modify_json.py
+++ b/modify_json.py
@@ -1,0 +1,37 @@
+import json
+from json_factory import IDCoder
+
+
+def mod_json(world, gp_vars_more_fn, sources, idc):
+    for src in sources:
+        with open(f"model_json/{src}") as f:
+            jsrc = json.load(f)
+        jsrc['world'] = world
+        jsrc['gp_vars_more'] = gp_vars_more_fn(jsrc['gp_vars_more'])
+        pref = next(idc)
+        jsrc['output_prefix'] = f"{pref}__"
+        jsrc['out_dir'] = f"output/{pref}"
+        with open(f'model_{pref}.json', 'w') as outf:
+            json.dump(jsrc, outf)
+
+if __name__ == '__main__':
+    sources = ['model_aa.json', 'model_am.json', 'model_an.json', 'model_ao.json']
+    idc = IDCoder(2, i=40)
+    worlds = ['SineWorld2', 'SineWorld3']
+    gvmfs = [
+        lambda gvm: gvm[:-1],
+        lambda gvm: gvm[:-3] + ['obs_centre', 'obs_log_radius']
+    ]
+    for w, g in zip(worlds, gvmfs):
+        mod_json(w, g, sources, idc)
+
+# world:
+# 1 - SineWorld2
+# 2 - SineWorld3
+
+# gp_vars_more:
+# 1 - lose last (obs_num)
+# 2 - obs_start, obs_stop -> obs_centre, obs_log_radius
+
+# output_prefix bo__ - bv__
+# out_dir output/bo - output/bv

--- a/philoso_py.py
+++ b/philoso_py.py
@@ -1,5 +1,5 @@
 from repository import Publication
-from world import World, SineWorld
+from world import World, SineWorld, SineWorld2, SineWorld3
 #from observatories import SineWorldObservatoryFactory
 from tree_factories import RandomPolynomialFactory, RandomTreeFactory, RandomAlgebraicTreeFactory, SimpleRandomAlgebraicTreeFactory
 from ppo import ActorCriticNetworkTanh, ActorCriticNetwork
@@ -537,7 +537,7 @@ class ModelFactory:
     # `nd` is a function that turns a collection of objects (classes
     # or functions) with a `__name__` attr into a dictionary in which 
     # the `__name__`s are the keys and the objects are the values 
-    worlds = nd(SineWorld)
+    worlds = nd(SineWorld, SineWorld2, SineWorld3)
     sb_factories = nd(
         SimpleGPScoreboardFactory, 
         SimplerGPScoreboardFactory

--- a/world.py
+++ b/world.py
@@ -889,7 +889,7 @@ class VectorWorld(World):
         return world
 
 # this contains a bunch of gymnasium.spaces stuff that isn't needed
-class SineWorld(World):
+class BaseSineWorld(World):
     addr = ['world_params']
     args = ['radius', 'max_observation_size', 'noise_sd']
     stargs = 'sine_wave_params'
@@ -1044,6 +1044,14 @@ class SineWorld(World):
             'obs_width': float(np.abs(stop-start)),
             'obs_num':   int(num)
         }
+
+class SineWorld(BaseSineWorld):
+    def __call__(
+            self, centre: float, log_radius: float, num: int, **kwargs: Any
+        ) -> Observatory:
+        radius = np.exp(log_radius)
+        return super().__call__(centre-radius, centre+radius, num, **kwargs)
+    
 
 
 def main():

--- a/world.py
+++ b/world.py
@@ -1002,7 +1002,6 @@ class SineWorld(World):
         """
         # Check that params are in the right range, raise ValueErrors
         # otherwise
-        from icecream import ic
         data = pd.DataFrame({
             self.iv: self.np_random.uniform(
                 low=start, high=stop, size=num


### PR DESCRIPTION
SineWorld2 extends SineWorld, by removing the observation number (`num`) param, so the number of datapoints in each observation is fixed at SineWorld.max_observation_size

SineWorld3 replaces the observation params `start` and `stop` with `centre` and `log_radius`, such that `start = centre - exp(log_radius)` and `stop = centre + exp(log_radius)`